### PR TITLE
fix for 'A017122' and 'A257975'

### DIFF
--- a/gfun.sage
+++ b/gfun.sage
@@ -43,7 +43,7 @@ def OEIS(T, num, info=false):  # needs internet
                 del Ux[-1]
             else:
                 del Ux[-1]
-            R = oeis(U, max_results=num)
+            R = oeis(Ux, max_results=num)
 
     L = []
     for r in R:

--- a/gfun.sage
+++ b/gfun.sage
@@ -16,16 +16,34 @@ def OEIS(T, num, info=false):  # needs internet
     if len(T) < 3: return []
 
     # disregard the first entry and trailing zeros
-    i, l = 1, len(T)
+    i, l = 0, len(T)
     while i < l and T[i] == 0: i += 1
     S = T[i:min(l, 20)] if (min(l, 20) - i) > 6 else T
 
     R = oeis(S, max_results=num)
 
     if len(R) == 0:
+        # what if S is too long?
+        Sx = S[:]
+        while len(", ".join([str(a) for a in Sx])) > 270:
+            del Sx[-1]
+        else:
+            del Sx[-1]
+        R = oeis(Sx, max_results=num)
+
+    if len(R) == 0:
         U = [z for z in S if z != 0]
         del U[0]
         R = oeis(U, max_results=num)
+
+        if len(R) == 0:
+            # what if U is too long?
+            Ux = U[:]
+            while len(", ".join([str(a) for a in Ux])) > 270:
+                del Ux[-1]
+            else:
+                del Ux[-1]
+            R = oeis(U, max_results=num)
 
     L = []
     for r in R:
@@ -133,7 +151,7 @@ class gfun(object):
         """
         r = g / g[0]
         r = r.shift(1)
-        r = r.reversion()
+        r = r.reverse()
         r = r.shift(-1)
         return r * g[0]
 

--- a/gfun.sage
+++ b/gfun.sage
@@ -16,7 +16,7 @@ def OEIS(T, num, info=false):  # needs internet
     if len(T) < 3: return []
 
     # disregard the first entry and trailing zeros
-    i, l = 0, len(T)
+    i, l = 1, len(T)
     while i < l and T[i] == 0: i += 1
     S = T[i:min(l, 20)] if (min(l, 20) - i) > 6 else T
 


### PR DESCRIPTION
If we run this test code:
```python
sage: attach('gfun.sage')
sage: for test in [17122, 257975]:
....:     for f in oeis(test).formulas():
....:         if ".f." in f.lower():
....:             f = f[5:]
....:             f = f[:f.find(".")]
....:             sage_eval("var('x')")
....:             gfun.explore_genfun(sage_eval(f))
```
before and after the proposed changes, the difference will be something like this: 
```diff
 Formal power series:  -1048576*(x^10 + 59038*x^9 + 9116141*x^8 + 178300904*x^7 + 906923282*x^6 + 1527092468*x^5 + 906923282*x^4 + 178300904*x^3 + 9116141*x^2 + 59038*x + 1)/(x - 1)^11
 
 None as_ogf [1048576, 61917364224, 10240000000000, 296196766695424, 3656158440062976, 27197360938418176, 144555105949057024, 604661760000000000, 2113922820157210624]
+A017122 (1048576, 61917364224, 10240000000000, 296196766695424, 3656158440062976, 27197360938418176, 144555105949057024, 604661760000000000, 2113922820157210624, 6428888932339941376)
+['A017122']
 
 None as_egf [1048576, 61917364224, 20480000000000, 1777180600172544, 87747802561511424, 3263683312610181120, 104079676283321057280, 3047495270400000000000, 85233368108738732359680]
 
@@ -9,6 +11,14 @@
 
 None as_bgf [1048576, 123834728448, 40960000000000, 2369574133563392, 58498535041007616, 870315550029381632, 9251526780739649536, 77396705280000000000, 541164241960245919744]
 
+rev as_ogf [1048576, -61917364224, 7302076880125952, -1076439486033160044544, 177725913849035155590610944, -31439460131300686138988993445888, 5826433228345980924064328736637452288, -1116578289224500276343751478764232340668416, 219467877571609507800756696982000711391975047168]
+
+rev as_egf [1048576, -61917364224, 14604153760251904, -6458636916198960267264, 4265421932376843734174662656, -3772735215756082336678679213506560, 4195031924409106265326316690378965647360, -5627554577691481392772507452971730996968816640, 8848944823687295354526510022314268683324433901813760]
+
+rev as_lgf [0, -61917364224, -14604153760251904, -3229318458099480133632, -710903655396140622362443776, -157197300656503430694944967229440, -34958599370075885544385972419824713728, -7816048024571501934406260351349626384678912, -1755743020572876062406053575856005691135800377344]
+
+rev as_bgf [1048576, -123834728448, 29208307520503808, -8611515888265280356352, 2843614621584562489449775104, -1006062724201621956447647790268416, 372891726614142779140117039144796946432, -142922021020736035372000189281821739605557248, 56183776658332033996993714427392182116345612075008]
+
 der as_ogf [61917364224, 20480000000000, 888590300086272, 14624633760251904, 135986804692090880, 867330635694342144, 4232632320000000000, 16911382561257684992, 57860000391059472384]
 
 der as_egf [61917364224, 20480000000000, 1777180600172544, 87747802561511424, 3263683312610181120, 104079676283321057280, 3047495270400000000000, 85233368108738732359680, 2332915215767517926522880]
@@ -39,6 +49,8 @@
 Formal power series:  -10*(211462*x^8 + 198379896430716*x^7 + 11072383489254815935515*x^6 + 34322119735654912553073*x^5 - 14213722750292211889419959*x^4 + 20568424419816146874*x^3 + 21924680085*x^2 + 297*x + 97)*x/((x^4 + 3461452808002*x^2 + 1)*(x^2 + 1860498*x + 1)*(x^2 - 1860498*x + 1)*(x - 1))
 
 None as_ogf [0, 970, 3940, 219246804790, 205684244417408273530, 11480068853945505053489115880, 47065929034956905708053692550, 2626939693541678540279445026253849400, 2464437767031050248773603452558570281788774040]
+A257975 (970, 3940, 219246804790, 205684244417408273530, 11480068853945505053489115880, 47065929034956905708053692550, 2626939693541678540279445026253849400, 2464437767031050248773603452558570281788774040, 137550230606703955058365608367051590003016395627772390)
+['A257975']
 
 None as_egf [0, 970, 7880, 1315480828740, 4936421866017798564720, 1377608262473460606418693905600, 33887468905168972109798658636000, 13239776055450059843008402932319400976000, 99366130766691946030551691207161553761723369292800]
 
@@ -59,6 +71,8 @@
 int as_egf [0, 0, 970, 7880, 1315480828740, 4936421866017798564720, 1377608262473460606418693905600, 33887468905168972109798658636000, 13239776055450059843008402932319400976000]
 
 int as_lgf [0, 0, -970, 3940, -219246804790, 205684244417408273530, -11480068853945505053489115880, 47065929034956905708053692550, -2626939693541678540279445026253849400]
+A257975 (970, 3940, 219246804790, 205684244417408273530, 11480068853945505053489115880, 47065929034956905708053692550, 2626939693541678540279445026253849400, 2464437767031050248773603452558570281788774040, 137550230606703955058365608367051590003016395627772390)
+['A257975']
 
 Launched png viewer for Graphics object consisting of 77 graphics primitives
 Done!
```